### PR TITLE
Bind the called controller method to the controller instance itself

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,7 +50,7 @@ export default class extends Controller {
         identifier
       )
       if (typeof key === 'string' && typeof controller[method] === 'function')
-        return [key, controller[method]]
+        return [key, controller[method].bind(controller)]
     } catch (err) {}
   }
 }


### PR DESCRIPTION
If, taking the example controller from the README, were to have a `ping` event like this:
```
ping() {
  this.element.innerHTML = 'PONG'
}
```

You would get a `TypeError: undefined is not an object (evaluating 'this.element.innerHTML = 'PONG'')` unless you bind the controller instance to the method. Otherwise, `this` in the context of the controller method is the `hotkeys-js` Object:
```
{
  key: "p",
  keydown: true,
  keyup: false,
  method: function(event),
  mods: [],
  scope: "all",
  shortcut: "p",
  splitKey: "+"
}
```