### PR TITLE
feat: Allow empty selectors in bindings values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,10 @@ export default class extends Controller {
   map (binding) {
     try {
       const [key, value] = binding
-      const [selector, target] = value.split('->')
+      let [selector, target] = value.split('->')
+      if (!target) {
+        [target, selector] = [selector, this.element]
+      }
       const [identifier, method] = target.split('#')
       const element = document.querySelector(selector)
       const controller = this.getControllerForElementAndIdentifier(


### PR DESCRIPTION
This commit let's custom binding values omit the `selector` part of binding values `selector->identifier#method`.
If it is omitted then the controller will use the HTML element to which the stimulus controller is bound.